### PR TITLE
Allow checking for multiple programs in bin/which

### DIFF
--- a/bin/which
+++ b/bin/which
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var which = require("../")
 if (process.argv.length < 3) {
-  console.error('Usage: which \u001b[4mprogram\u001b[24m ...')
+  console.error('Usage: which <program>...')
   process.exit(1)
 }
 

--- a/bin/which
+++ b/bin/which
@@ -10,7 +10,6 @@ process.exit(process.argv.slice(2).reduce(function(pv, current) {
     console.log(which.sync(current))
     return pv;
   } catch (e) {
-    console.error(e.message)
     return 1;
   }
 }, 0))

--- a/bin/which
+++ b/bin/which
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 var which = require("../")
 if (process.argv.length < 3) {
-  console.error("Usage: which <thing>")
+  console.error('Usage: which \u001b[4mprogram\u001b[24m ...')
   process.exit(1)
 }
 
-which(process.argv[2], function (er, thing) {
-  if (er) {
-    console.error(er.message)
-    process.exit(er.errno || 127)
+process.exit(process.argv.slice(2).reduce(function(pv, current) {
+  try {
+    console.log(which.sync(current))
+    return pv;
+  } catch (e) {
+    console.error(e.message)
+    return 1;
   }
-  console.log(thing)
-})
+}, 0))


### PR DESCRIPTION
Returns `1` no matter the number of failures, as that's how Linux and OS X `which` behaves, too. Usage output adjusted to indicate that multiple arguments are accepted.