### PR TITLE
Remove unused `is-absolute` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "bin": "./bin/which",
   "license": "ISC",
   "dependencies": {
-    "is-absolute": "^0.1.7",
     "isexe": "^1.1.1"
   },
   "devDependencies": {

--- a/which.js
+++ b/which.js
@@ -9,7 +9,6 @@ var path = require('path')
 var COLON = isWindows ? ';' : ':'
 var isexe = require('isexe')
 var fs = require('fs')
-var isAbsolute = require('is-absolute')
 
 function getNotFoundError (cmd) {
   var er = new Error('not found: ' + cmd)


### PR DESCRIPTION
It's no longer needed since https://github.com/npm/node-which/commit/afabffc81df7554fec86ed6b55f4e59e96818f3d, bit still in the `dependencies` field in package.json.
