### PR TITLE
Do not needlessly require bash

### DIFF
--- a/changelog.sh
+++ b/changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 (
   echo '# Changes'
   echo ''


### PR DESCRIPTION
This script does not need any bash features and works fine with any POSIX-compliant shell. Fix for systems which do not have /bin/bash (e.g. FreeBSD).