### PR TITLE
Add PATHEXT tests

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -84,8 +84,6 @@ t.test('find when executable', function (t) {
   t.test('with pathExt', {
     skip: isWindows ? false : 'Only for Windows'
   }, function (t) {
-    var pe = process.env.PATHEXT
-    process.env.PATHEXT = '.SH'
     process.env.PATH = fixture
 
     t.test('foo.sh', function (t) {
@@ -95,6 +93,24 @@ t.test('find when executable', function (t) {
     t.test('foo', function (t) {
       process.env.PATH = fixture
       runTest('foo', t)
+    })
+    t.end()
+  })
+
+  t.test('with process.env.PATHEXT', {
+    skip: isWindows ? false : 'Only for Windows'
+  }, function (t) {
+    var pe = process.env.PATHEXT
+    process.env.PATHEXT = '.SH'
+    process.env.PATH = fixture
+
+    t.test('foo.sh', function (t) {
+      process.env.PATH = fixture
+      runTest('foo.sh', t, {})
+    })
+    t.test('foo', function (t) {
+      process.env.PATH = fixture
+      runTest('foo', t, {})
     })
     t.test('replace', function (t) {
       process.env.PATHEXT = pe
@@ -150,13 +166,16 @@ t.test('find when executable', function (t) {
     })
   })
 
-  function runTest(exec, t) {
+  function runTest(exec, t, options) {
     t.plan(2)
 
-    var found = which.sync(exec, opt).toLowerCase()
+    if (!options)
+      options = opt
+
+    var found = which.sync(exec, options).toLowerCase()
     t.equal(found, expect)
 
-    which(exec, opt, function (er, found) {
+    which(exec, options, function (er, found) {
       if (er)
         throw er
       t.equal(found.toLowerCase(), expect)


### PR DESCRIPTION
The tests `find when executable > with pathExt` were setting
`process.env.PATHEXT`, as if to test to ensure that it would read from
it correctly. But in both tests, the option `pathExt` was also set.
This option is checked before `PATHEXT`, so `PATHEXT` was not tested.

The `addTest` function has been given an additional optional parameter
to specify a non-default set of options. New tests have been added to
ensure `PATHEXT` is read correctly.