### PR TITLE
Support case-sensitive windows directories

### DIFF
--- a/which.js
+++ b/which.js
@@ -34,6 +34,11 @@ function getPathInfo (cmd, opt) {
     // it's found in the pathExt set.
     if (cmd.indexOf('.') !== -1 && pathExt[0] !== '')
       pathExt.unshift('')
+
+    // Check both upper and lower-case, for case-sensitive directories
+    for (var i = 0, l = pathExt.length; i < l; i ++) {
+      pathExt.push(pathExt[i].toLowerCase());
+    }
   }
 
   // If it has a slash, then we don't bother searching the pathenv.


### PR DESCRIPTION
Checks for both upper-case and lower-case file extensions. This is to
support case-sensitive directories on Windows.

Mixed-case file extensions still won't work, but those are rare enough
that I don't think it's worth the performance cost to check those as
well.

Closes #57