### PR TITLE
Remove entry for Node.js v4, add Node.js v8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
+    - nodejs_version: '8'
     - nodejs_version: '6'
-    - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true


### PR DESCRIPTION
Node.js v4 is well past End-of-life. Node.js v4 builds for this project
are consistently failing with errors from within the npm cli.

Node.js v8 is the current LTS, and would be more useful to test.