### PR TITLE
feat(prioritizedPaths): allow NPX to safely conform to NPM behavior when dealing with paths that include `path.delimiter`

### DIFF
--- a/which.js
+++ b/which.js
@@ -55,7 +55,7 @@ function which (cmd, opt, cb) {
   }
 
   var info = getPathInfo(cmd, opt)
-  var pathEnv = info.env
+  var pathEnv = [].concat((opt.prioritizedPaths || []), info.env)
   var pathExt = info.ext
   var pathExtExe = info.extExe
   var found = []
@@ -96,7 +96,7 @@ function whichSync (cmd, opt) {
   opt = opt || {}
 
   var info = getPathInfo(cmd, opt)
-  var pathEnv = info.env
+  var pathEnv = [].concat((opt.prioritizedPaths || []), info.env)
   var pathExt = info.ext
   var pathExtExe = info.extExe
   var found = []


### PR DESCRIPTION
See: https://github.com/zkat/npx/pull/208

EDIT: looks like the AppVeyor tests are failing for some reason external to this PR...