### PR TITLE
Expand user relative paths

### DIFF
--- a/which.js
+++ b/which.js
@@ -8,6 +8,7 @@ var isWindows = process.platform === 'win32' ||
 var path = require('path')
 var COLON = isWindows ? ';' : ':'
 var isexe = require('isexe')
+var os = require('os')
 
 function getNotFoundError (cmd) {
   var er = new Error('not found: ' + cmd)
@@ -35,6 +36,11 @@ function getPathInfo (cmd, opt) {
     if (cmd.indexOf('.') !== -1 && pathExt[0] !== '')
       pathExt.unshift('')
   }
+
+  // Expand all user paths that begin with ~/
+  for (let i = 0 ; i < pathEnv.length ; i++)
+    if (pathEnv[i].substring(0, 2) == '~/')
+      pathEnv[i] = path.resolve(os.homedir(), pathEnv[i].substring(2))
 
   // If it has a slash, then we don't bother searching the pathenv.
   // just check the file itself, and that's it.


### PR DESCRIPTION
On my Mac the $PATH has `~/.npm-global/bin` in it, so any executables installed by `npm install -g` were not being detected...

Oddly enough the builtin `which` command on Mac also couldn't detect them, yet I could actually run those executables from the command line by just specifying the name, I don't know why that is...