### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/bin/node-which
+++ b/bin/node-which
@@ -20,7 +20,7 @@ var args = process.argv.slice(2).filter(function (arg) {
     return false
   }
 
-  var flags = arg.substr(1).split('')
+  var flags = arg.slice(1).split('')
   for (var f = 0; f < flags.length; f++) {
     var flag = flags[f]
     switch (flag) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.