### PR TITLE
Fix Node.js v4 build, add Node.js v8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,14 @@
 environment:
   matrix:
+    - nodejs_version: '8'
     - nodejs_version: '6'
     - nodejs_version: '4'
+    
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true
-  - npm -g install npm@latest
-  - set PATH=%APPDATA%\npm;%PATH%
+  - if not "%nodejs_version%" == "4" npm -g install npm@latest
+  - if not "%nodejs_version%" == "4" set PATH=%APPDATA%\npm;%PATH%
   - npm install
 matrix:
   fast_finish: true


### PR DESCRIPTION
When using Node.js v4, the command `npm install -g npm` will install a version of npm incompatible with Node.js v4. As a workaround, that step has been omitted for Node.js v4, and instead the default version of npm is used.

Node.js v8 as been added as well, as it is the current LTS version of Node.js.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

#Claim and own complete control assess to my organization #24elinagittHuB
## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
