### PR TITLE
docs: Replace binary `which` with `node-which` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ Just like the BSD `which(1)` binary but using `node-which`.
 usage: node-which [-as] program ...
 ```
 
-We used to use `which` as the binaray's name, but it result in some issues later, 
-so we renamed it to `node-which`. You can learn more about this 
-[here](https://github.com/npm/node-which/commit/d65012c1af5d5424bef9fd7c22ad42613804dbab)
+You can learn more about why the binary is `node-which` and not `which` 
+[here](https://github.com/npm/node-which/pull/67)
 
 ## OPTIONS
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ await which('node', { path: someOtherPath, pathExt: somePathExt })
 
 ## CLI USAGE
 
-Same as the BSD `which(1)` binary.
+Just like the BSD `which(1)` binary but using `node-which`.
 
 ```
-usage: which [-as] program ...
+usage: node-which [-as] program ...
 ```
+
+We used to use `which` as the binaray's name, but it result in some issues later, 
+so we renamed it to `node-which`. You can learn more about this 
+[here](https://github.com/npm/node-which/commit/d65012c1af5d5424bef9fd7c22ad42613804dbab)
 
 ## OPTIONS
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fix https://github.com/npm/node-which/issues/96